### PR TITLE
Bugfix/cannot import gedcom file or add media files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="22" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/app/familygem/MediaFoldersActivity.java
+++ b/app/src/main/java/app/familygem/MediaFoldersActivity.java
@@ -39,9 +39,22 @@ public class MediaFoldersActivity extends BaseActivity {
         updateList();
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         findViewById(R.id.fab).setOnClickListener(v -> {
-            int perm = ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
+            final String[] requiredPermissions;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                requiredPermissions = new String[] {
+                        Manifest.permission.READ_MEDIA_IMAGES,
+                        Manifest.permission.READ_MEDIA_VIDEO,
+                        Manifest.permission.READ_MEDIA_AUDIO,
+                };
+            } else {
+                requiredPermissions = new String[] {
+                        Manifest.permission.READ_EXTERNAL_STORAGE,
+                };
+            }
+
+            final int perm = F.checkMultiplePermissions(this, requiredPermissions);
             if (perm == PackageManager.PERMISSION_DENIED)
-                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 3517);
+                ActivityCompat.requestPermissions(this, requiredPermissions, 3517);
             else if (perm == PackageManager.PERMISSION_GRANTED)
                 chooseFolder();
         });


### PR DESCRIPTION
Application targeting the Android 13 (API 33) can't use the `READ_EXTERNAL_STORAGE` permission anymore.
Instead, the more detailed permissions should be used.

Fix: Use correct permissions on API below and above 33.

Refers: #71 

Tested on:
- Pixel 3 (API 31)
- Android emulator (API 33)