### PR TITLE
feat(export): add option to export PNG

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,7 +164,9 @@
     <string name="unlink">Unlink</string>
     <string name="long_press_menu">Long press to display the menu.\nTap to open the profile.</string>
     <string name="export_pdf">Export PDF</string>
+    <string name="export_png">Export PNG</string>
     <string name="pdf_exported_ok">PDF exported.</string>
+    <string name="png_exported_ok">PNG exported.</string>
     <string name="diagram_settings">Diagram settings</string>
     <string name="generations_display_diagram">Set how many generations display in the diagram:</string>
     <string name="ancestors">Ancestors</string>


### PR DESCRIPTION
This PR adds menu item "Export PNG" to export the current tree as PNG. 
Following the example to export as PDF.

<img width="600" alt="Screenshot_Family Gem" src="https://github.com/michelesalvador/FamilyGem/assets/17972991/6bfcfc55-e33c-40d9-a738-809d43d9e3ba">


related with #136